### PR TITLE
Upgrade to norbert2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bert-bot
 
-A Discord bot that utilizes the [BERT](https://en.wikipedia.org/wiki/BERT_(language_model)) and [NorBERT](http://wiki.nlpl.eu/Vectors/norlm/norbert) language models to make word predictions within text.
+A Discord bot that utilizes the [BERT](https://en.wikipedia.org/wiki/BERT_(language_model)) and [NorBERT 2](http://wiki.nlpl.eu/Vectors/norlm/norbert) language models to make word predictions within text.
 
 ## Run
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -51,4 +51,4 @@ async def on_ready():
     )
 
 
-bot.run(os.getenv("DISCORD_TOKEN"), bot=True, reconnect=True)
+bot.run(os.getenv("DISCORD_TOKEN"), reconnect=True)

--- a/src/bot.py
+++ b/src/bot.py
@@ -23,6 +23,7 @@ class Bot(commands.Bot):
             command_prefix=commands.when_mentioned_or(os.getenv("PREFIX")),
             case_insensitive=True,
             allowed_mentions=mentions,
+            intents=discord.Intents.default(),
             help_command=None
         )
 

--- a/src/cogs/bert.py
+++ b/src/cogs/bert.py
@@ -16,9 +16,9 @@ mask_id = tokenizer("[MASK]", add_special_tokens=False).input_ids[0]
 stopword_ids = stopwords.get_stopword_ids(tokenizer, stopwords.english, cased=False)
 model.eval()
 
-nor_tokenizer = BertTokenizer.from_pretrained("ltgoslo/norbert")
+nor_tokenizer = BertTokenizer.from_pretrained("ltgoslo/norbert2")
 nor_tokenizer.unique_no_split_tokens.extend(nosplit_tokens)
-nor_model = BertForMaskedLM.from_pretrained("ltgoslo/norbert")
+nor_model = BertForMaskedLM.from_pretrained("ltgoslo/norbert2")
 nor_mask_id = nor_tokenizer("[MASK]", add_special_tokens=False).input_ids[0]
 nor_stopword_ids = stopwords.get_stopword_ids(nor_tokenizer, stopwords.norwegian, cased=True)
 nor_model.eval()


### PR DESCRIPTION
Swaps out the norbert for norbert2, electric boogaloo. Commands are still the same, though it would maybe be interesting to have seperate commands for norbert and norbert2.

Added some additional changes in order to be stay up to date with the latest versions of discord.py.